### PR TITLE
Fix module requires and dependency declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,16 @@
 			<artifactId>jpt</artifactId>
 			<version>3.2.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.cicirello</groupId>
+			<artifactId>rho-mu</artifactId>
+			<version>1.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.cicirello</groupId>
+			<artifactId>core</artifactId>
+			<version>1.1.0</version>
+		</dependency>
 	</dependencies>
   
 	<properties>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /*
  * Example programs for JavaPermutationTools library.
- * Copyright (C) 2018-2021  Vincent A. Cicirello
+ * Copyright (C) 2018-2022 Vincent A. Cicirello
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,5 +29,7 @@ module org.cicirello.examples.jpt {
 	exports org.cicirello.replication.flairs2013;
 	exports org.cicirello.replication.ieeetevc2016;
 	requires org.cicirello.jpt;
+	requires org.cicirello.rho_mu;
+	requires org.cicirello.core;
 	requires java.management;
 }


### PR DESCRIPTION
## Summary
Fix module requires and dependency declarations. Something changed in most recent JPT that now requires examples module to explicitly require JPT's dependencies. This is now fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
