### PR TITLE
Removed transitive dependencies from pom.xml of jpt-examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
 	<groupId>org.cicirello</groupId>
 	<artifactId>jpt-examples</artifactId>
-	<version>4.0.0</version>
+	<version>4-SNAPSHOT</version>
 	<packaging>jar</packaging>
   
 	<name>JavaPermutationTools (JPT) Example Programs</name>
@@ -151,16 +151,6 @@
 			<artifactId>jpt</artifactId>
 			<version>4.3.1</version>
 		</dependency>
-		<dependency>
-			<groupId>org.cicirello</groupId>
-			<artifactId>rho-mu</artifactId>
-			<version>2.5.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.cicirello</groupId>
-			<artifactId>core</artifactId>
-			<version>2.4.3</version>
-		</dependency>
 	</dependencies>
   
 	<properties>
@@ -214,5 +204,4 @@
 			</plugin>
 		</plugins>
 	</build>
-  
 </project>


### PR DESCRIPTION
## Summary
We were previously declaring the dependencies of jpt in the pom.xml in addition to declaring jpt as a dependency. A bug in jpt's pom made this necessary. That bug was resolved in jpt 4.3.1. Therefore, we've removed the transitive dependencies from the pom.xml of jpt-examples, allowing Maven to do its thing and get the appropriate versions of jpt's dependencies.